### PR TITLE
FEATURE: Consider neutral checks as success

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ async function getCheckStatus(pr) {
 
   if (runs.length < 1) {
     return "missing";
-  } else if (runs.every((r) => r.conclusion === "success")) {
+  } else if (runs.every((r) => ["success", "neutral"].includes(r.conclusion))) {
     return "success";
   } else if (runs.some((r) => r.status === "queued")) {
     return "queued";


### PR DESCRIPTION
Some checks, like the LGTM analysis, have a conclusion of "neutral" instead of "success". This makes both work the same.