### PR TITLE
FEATURE: Make PR title matching case-insensitive

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,8 +187,7 @@ async function listAll(owner, title, author, { ignoreChecks = false } = {}) {
       continue;
     }
 
-    const titleRegex = new RegExp(`${title}$`, "i");
-    if (!titleRegex.test(pr.title)) {
+    if (!pr.title.toLowerCase().endsWith(title.toLowerCase())) {
       console.log(`invalid PR title: "${pr.title}" expected: "${title}"`);
       continue;
     }

--- a/index.js
+++ b/index.js
@@ -187,7 +187,8 @@ async function listAll(owner, title, author, { ignoreChecks = false } = {}) {
       continue;
     }
 
-    if (!pr.title.endsWith(title)) {
+    const titleRegex = new RegExp(`${title}$`, "i");
+    if (!titleRegex.test(pr.title)) {
       console.log(`invalid PR title: "${pr.title}" expected: "${title}"`);
       continue;
     }


### PR DESCRIPTION
In some cases Dependabot PRs start with a lowercase letter, e.g. "bump minimatch from 3.0.4 to 3.1.2"