### PR TITLE
FIX: Don't crash on merge errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,13 +43,20 @@ async function approve(owner, repo, pullNumber) {
 }
 
 async function merge(owner, repo, pullNumber) {
-  await octokit.request("PUT /repos/{owner}/{repo}/pulls/{pullNumber}/merge", {
-    owner,
-    repo,
-    pullNumber,
-    merge_method: "squash",
-  });
-  console.log("and merged");
+  try {
+    await octokit.request(
+      "PUT /repos/{owner}/{repo}/pulls/{pullNumber}/merge",
+      {
+        owner,
+        repo,
+        pullNumber,
+        merge_method: "squash",
+      }
+    );
+    console.log("and merged");
+  } catch (error) {
+    console.error(`NOT MERGED ❗️ (${error.message})`);
+  }
 }
 
 function extractUrlParts(url) {


### PR DESCRIPTION
Just logs an error, like:

"NOT MERGED ❗️ (Squash merges are not allowed on this repository.)"

…and moves on.